### PR TITLE
fix todo changing font size

### DIFF
--- a/l4proj.cls
+++ b/l4proj.cls
@@ -308,7 +308,7 @@ textfont=it,tableposition=above]{caption}
 
 % allow highlighting of text for todo notes
 \usepackage{soul}
-\newcommand{\todo}[1]{\large \hl{TODO: #1}\PackageWarning{TODO:}{#1!}}
+\newcommand{\todo}[1]{\large \hl{TODO: #1}\PackageWarning{TODO:}{#1!} \normalsize}
 
 % make urls less bulky and ugly
 \renewcommand{\UrlFont}{\ttfamily\small}


### PR DESCRIPTION
At the moment, using a `\todo` command will set the rest of the document to use a `\large` font size, which makes it rather hard to estimate page counts and layouts of later pages while writing. This change resets the size to normal size after the todo message is placed.